### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["esp2in9bv2.py", "github:rdagger/MicroPython-2.9-inch-ePaper-Library/esp2in9bv2.py"],
+    ["xglcd_font.py", "github:rdagger/MicroPython-2.9-inch-ePaper-Library/xglcd_font.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
## Summary
- Add package.json file to make this library installable via the MicroPython Package Manager (MIP)
- Enables installation with `mip install github:rdagger/MicroPython-2.9-inch-ePaper-Library`
- Includes the main library modules needed for basic functionality

## Test plan
- Verify that the package can be installed using MIP

🤖 Generated with [Claude Code](https://claude.ai/code)